### PR TITLE
update peg and node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
   - 0.10
+  - 0.12
+  - 4.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-peg",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Gulp plugin for compiling PEG grammars",
   "main": "index.js",
   "scripts": {
@@ -34,6 +34,6 @@
   "dependencies": {
     "through2": "^0.4.1",
     "gulp-util": "^2.2.14",
-    "pegjs": "^0.8.0"
+    "pegjs": "^0.9.0"
   }
 }


### PR DESCRIPTION
Hello, I've updated the package to use the latest [peg](https://github.com/pegjs/pegjs) version, [0.9.0](https://github.com/pegjs/pegjs/blob/master/CHANGELOG.md#090).

I've also updated the node versions tested on travis, and the package version.
